### PR TITLE
Fixing Bug 4265568

### DIFF
--- a/src/ResourceManagement/AzureBackup/BackupServicesManagement/Generated/VaultOperations.cs
+++ b/src/ResourceManagement/AzureBackup/BackupServicesManagement/Generated/VaultOperations.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Management.BackupServices
                         TracingAdapter.ReceiveResponse(invocationId, httpResponse);
                     }
                     HttpStatusCode statusCode = httpResponse.StatusCode;
-                    if (statusCode != HttpStatusCode.OK)
+                    if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.NoContent)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         CloudException ex = CloudException.Create(httpRequest, null, httpResponse, await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false));


### PR DESCRIPTION
Fixing Bug 4265568: Remove-AzureBackupVault twice returns No Content in exception
